### PR TITLE
Solution

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "GPL-3.0",
   "devDependencies": {
     "@mate-academy/eslint-config": "*",
-    "@mate-academy/scripts": "^0.3.5",
+    "@mate-academy/scripts": "^0.9.0",
     "eslint": "^5.16.0",
     "eslint-plugin-jest": "^22.4.1",
     "eslint-plugin-node": "^8.0.1",

--- a/src/convertToObject.js
+++ b/src/convertToObject.js
@@ -12,7 +12,17 @@
  * @return {object}
  */
 function convertToObject(sourceString) {
-  // write your code here
+  const arr = sourceString.split('\n');
+  const clearSpaces = arr.map((item) => item.trim());
+  const clearSmallItems = clearSpaces.filter((item) => item.length > 1);
+  const clearSemicolons = clearSmallItems.map((item) => item.slice(0, -1));
+  const pairs = clearSemicolons.map((item) => item.split(':'));
+  const trimPairs = pairs.map((item) => [item[0].trim(), item[1].trim()]);
+  const object = {};
+
+  trimPairs.forEach((item) => (object[item[0]] = item[1]));
+
+  return object;
 }
 
 module.exports = convertToObject;


### PR DESCRIPTION
Привіт!

Я хотів скоротити кількість змінних шляхом заміни методу map на forEach, але тоді тести злітали або повністю (приклад №1), або частково (приклад №2).

Приклад №1:
```
const clearSpaces = arr.map((item) => item.trim());
arr.forEach((item) => (item.trim());

```

Приклад №2:
```
const trimPairs = pairs.map((item) => [item[0].trim(), item[1].trim()]);
trimPairs.forEach((item) => [item[0].trim(), item[1].trim()]);

```
Хоча при перетворенні масиву на об’єкт forEach спрацював успішно.

Чому тоді в інших випадках цей метод не проходив всі тести?