### PR TITLE
Develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "GPL-3.0",
   "devDependencies": {
     "@mate-academy/eslint-config": "latest",
-    "@mate-academy/scripts": "^1.7.3",
+    "@mate-academy/scripts": "^1.7.8",
     "eslint": "^7.32.0",
     "eslint-plugin-jest": "^22.4.1",
     "eslint-plugin-node": "^8.0.1",

--- a/src/convertToObject.js
+++ b/src/convertToObject.js
@@ -6,7 +6,44 @@
  * @return {object}
  */
 function convertToObject(sourceString) {
-  // write your code here
+  const result = {};
+
+  // rulesString === [
+  //   '  width:   15px   ',
+  //   'padding:    15px',
+  // ]
+  // Trim all surrounding white spaces and split each rule on a semi-colon
+  const rulesStrings = sourceString.trim().split(';');
+
+  // Map through key value pair strings
+  // Elements are long strings with white spaces === '  width:   15px   ',)
+  const keyValueStringArray = rulesStrings.map(function (rule) {
+    // Separate each key and a value
+    const keyValuePair = rule.split(':');
+
+    // Trim both the key and the value
+    const trimmedKeyValuePair = keyValuePair.map((element) => element.trim());
+
+    return trimmedKeyValuePair;
+  }, rulesStrings);
+
+  // Remove empty elements created cause of extra semicolons
+  const keyValueArray = keyValueStringArray.filter(
+    (element) => element[0].length > 0,
+  );
+
+  // Sort the rules alphabetically
+  const sortedRules = keyValueArray.sort((a, b) => a[0].localeCompare(b[0]));
+
+  // Add key value pairs to the result object
+  sortedRules.forEach(function (rule) {
+    const key = rule[0];
+    const value = rule[1];
+
+    result[key] = value;
+  });
+
+  return result;
 }
 
 module.exports = convertToObject;


### PR DESCRIPTION
Eslint didn't allow chaining like this, had to leave methods on the same line:

GOOD EXAMPLE: 
```
const cssStyles = styles
 .map(style => style)
 .filter(style => style.length)
 .slice(0, 5)
```